### PR TITLE
Fixes #8 - adding a fake voltage sensor

### DIFF
--- a/fakeHardware/src/main/java/com/ftc9929/testing/fakes/sensors/FakeVoltageSensor.java
+++ b/fakeHardware/src/main/java/com/ftc9929/testing/fakes/sensors/FakeVoltageSensor.java
@@ -1,0 +1,47 @@
+package com.ftc9929.testing.fakes.sensors;
+
+import com.qualcomm.robotcore.hardware.VoltageSensor;
+
+public class FakeVoltageSensor implements VoltageSensor {
+
+    private double voltage = 12;
+
+    @Override
+    public double getVoltage() {
+        return voltage;
+    }
+
+    public void setVoltage(double newVoltage) {
+        voltage = newVoltage;
+    }
+
+    @Override
+    public Manufacturer getManufacturer() {
+        return Manufacturer.Other;
+    }
+
+    @Override
+    public String getDeviceName() {
+        return "TNT Fake Voltage Sensor";
+    }
+
+    @Override
+    public String getConnectionInfo() {
+        return "";
+    }
+
+    @Override
+    public int getVersion() {
+        return 0;
+    }
+
+    @Override
+    public void resetDeviceConfigurationForOpMode() {
+
+    }
+
+    @Override
+    public void close() {
+
+    }
+}

--- a/fakeHardware/src/main/java/com/ftc9929/testing/fakes/util/FakeHardwareMapFactory.java
+++ b/fakeHardware/src/main/java/com/ftc9929/testing/fakes/util/FakeHardwareMapFactory.java
@@ -28,6 +28,7 @@ import com.ftc9929.testing.fakes.drive.FakeServo;
 import com.ftc9929.testing.fakes.sensors.FakeDigitalChannel;
 import com.ftc9929.testing.fakes.sensors.FakeDistanceSensor;
 import com.ftc9929.testing.fakes.sensors.FakeRevTouchSensor;
+import com.ftc9929.testing.fakes.sensors.FakeVoltageSensor;
 import com.qualcomm.robotcore.hardware.HardwareMap;
 
 import org.w3c.dom.Document;
@@ -119,6 +120,8 @@ public class FakeHardwareMapFactory {
 
             // FIXME: Add implementations for things we don't support, but need:
             // IMU, LynxColorSensor, RevColorSensorV3, AnalogInput
+
+            hardwareMap.voltageSensor.put("Voltage Sensor", new FakeVoltageSensor());
         }
 
         private void addAllDistanceSensors(Document doc) {

--- a/fakeHardware/src/test/java/com/ftc9929/testing/fakes/sensors/FakeVoltageSensorTest.java
+++ b/fakeHardware/src/test/java/com/ftc9929/testing/fakes/sensors/FakeVoltageSensorTest.java
@@ -1,0 +1,44 @@
+/*
+ Copyright (c) 2021 The Tech Ninja Team (https://ftc9929.com)
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+ */
+
+package com.ftc9929.testing.fakes.sensors;
+
+import com.ftc9929.testing.fakes.util.FakeHardwareMapFactory;
+import com.qualcomm.robotcore.hardware.HardwareMap;
+
+import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+
+public class FakeVoltageSensorTest {
+    @Test
+    public void simple() {
+        HardwareMap fakeHwMap = FakeHardwareMapFactory.getFakeHardwareMap("sample_hardware_map.xml");
+
+        FakeVoltageSensor fakeVoltageSensor = (FakeVoltageSensor)fakeHwMap.voltageSensor.iterator().next();
+
+        Assertions.assertEquals(12, fakeVoltageSensor.getVoltage(),.01);
+
+        fakeVoltageSensor.setVoltage(0);
+
+        Assertions.assertEquals(0, fakeVoltageSensor.getVoltage(),.01);
+    }
+}

--- a/fakeHardware/src/test/java/com/ftc9929/testing/fakes/util/FakeHardwareMapTest.java
+++ b/fakeHardware/src/test/java/com/ftc9929/testing/fakes/util/FakeHardwareMapTest.java
@@ -42,6 +42,8 @@ public class FakeHardwareMapTest {
         assertDevicesPresent(fakeHwMap, DcMotorEx.class, 1);
         assertDevicesPresent(fakeHwMap, RevTouchSensor.class, 1);
         assertDevicesPresent(fakeHwMap, DigitalChannel.class, 1); // because our fake TS is a DC
+
+        Assertions.assertEquals(1, fakeHwMap.voltageSensor.size());
     }
 
     private void assertDevicesPresent(final HardwareMap fakeHwMap,


### PR DESCRIPTION
Created a fake voltage sensor class. Automaticly loaded into fake hardware maps